### PR TITLE
Implement Termux API background apply flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,145 +1,43 @@
-# Termux Background
+# Termux Background (Android companion)
 
-A Termux plugin and Android companion app that lets you set a background image in your terminal — just like Windows Terminal. Supports opacity, scroll animation, blur effect, and real-time application using `termux-reload-settings`.
+A WebView-based helper that copies a chosen PNG/JPEG into Termux's background and updates `~/.termux/termux.properties`, then reloads settings via **Termux:API**.
 
----
+## Hard requirements (must be installed)
+- [Termux](https://f-droid.org/en/packages/com.termux/)
+- [Termux:API](https://f-droid.org/en/packages/com.termux.api/)
 
-## ✨ Features
+> Apply/Reset stay **disabled** until Termux **and** Termux:API are detected. The app blocks writes if dependencies are missing.
 
-- 📷 **Select background image** (PNG or JPEG)
-- 🎚️ **Opacity control** via slider
-- 🌀 **Scroll animation toggle**
-- 🌫️ **Blur effect toggle**
-- ⚡ Applies instantly using Termux's runtime settings
+## What it does
+1. Lets you pick an image with the Storage Access Framework (no legacy storage permissions).
+2. Preview + tune opacity, blur, and animation (scroll/none).
+3. Writes only when you press **Apply**:
+   - `~/.termux/background.png`
+   - merges the following keys into `~/.termux/termux.properties` while preserving all other lines/comments:
+     - `background=background.png`
+     - `background.opacity=<value>`
+     - `background.blur=<true|false>`
+     - `background.animation=<scroll|none>`
+4. Invokes **Termux:API** to broadcast `termux-reload-settings` and surfaces success/failure in the UI.
+5. **Reset Background** removes the background-related keys, deletes `background.png`, and triggers reload (also blocked if Termux:API is absent).
 
----
+## Usage
+1. Install Termux and Termux:API from F-Droid.
+2. Install this APK (or build locally with `./gradlew assembleRelease`).
+3. Open the app:
+   - Tap **Re-check** if Apply is disabled.
+   - Choose an image → adjust options → press **Apply Background**.
+   - Press **Reset Background** to clear the settings and reload.
 
-## 🚀 Installation
+## Troubleshooting
+- **Apply is disabled**: Install or re-open Termux:API; press **Re-check**.
+- **Reload failed**: Ensure Termux:API is installed and allowed to receive broadcasts.
+- **Unsupported image**: Only PNG/JPEG are accepted.
 
-### 📦 Option A: Install the `.deb` CLI Plugin (recommended)
+## Development
+- Build: `./gradlew assembleDebug`
+- The WebView loads `app/src/main/assets/termux-background-ui.html`.
+- Native bridge lives in `app/src/main/java/com/termuxbackground/WebAppInterface.java` and uses the Termux:API broadcast `com.termux.api.action.RUN_COMMAND`.
 
-```bash
-wget https://github.com/Justadudeinspace/termux-background/releases/download/v1.0.2/termux-background_1.0.2_all.deb
-dpkg -i termux-background_1.0.2_all.deb
-```
-
-Then apply background using:
-
-```
-termux-background
-```
-
-🤖 Option B: Install the Android WebView App (UI-based)
-
-```
-adb install app-release.apk
-```
-
-Launch the app → choose your image → adjust options → click “Set as Termux Background”.
-
-
----
-
-🛠 How It Works
-
-Your selected image is copied to:
-~/.termux/background.png
-
-These settings are written to:
-~/.termux/termux.properties
-
-```
-background=background.png
-background.opacity=0.8
-background.animation=scroll
-background.blur=false
-```
-
-Finally, this is executed:
-
-```
-termux-reload-settings
-```
-
-
----
-
-🧪 Debugging
-
-To manually trigger reload or inspect config:
-
-```
-termux-reload-settings
-cat ~/.termux/termux.properties
-```
-
----
-
-👨‍💻 Development
-
-🔨 Build APK (Android app)
-
-```
-./gradlew clean assembleRelease
-```
-
-📦 Build .deb plugin for Termux
-
-```
-bash build-deb.sh
-```
-
-🧪 Test locally
-
-```
-adb install -r app/build/outputs/apk/release/app-release.apk
-dpkg -i termux-background_1.0.2_all.deb
-```
-
----
-
-📁 File Map
-
-File	Purpose
-
-background.png	Terminal background image
-termux.properties	Terminal appearance settings
-termux-background (CLI)	Shell script to apply background
-termux-background-ui.html	WebView frontend (inside app)
-
-
-
----
-
-📜 License
-
+## License
 MIT License © 2025 Justadudeinspace
-
----
-
-
----
-
-## 🤝 Credits & Contributors
-
-This project was developed with support from:
-
-- [ChatGPT](https://openai.com/chatgpt) – for AI pair programming, logic refactoring, and automation scripting
-- [Blackbox.ai](https://www.blackbox.ai) – for rapid code prototyping and interface scaffolding
-
----
-
-## 📲 Required Termux Components
-
-For this plugin to work, you must have the following installed:
-
-- [Termux App (F-Droid)](https://f-droid.org/en/packages/com.termux/)  
-  > ⚠️ **Do not install from Google Play Store** — it is outdated and unsupported
-
-- [Termux:API](https://f-droid.org/en/packages/com.termux.api/)  
-  > Used to run `am broadcast` and access runtime hooks
-
-Install both with:
-
-```bash
-pkg install termux-api

--- a/app/src/main/assets/termux-background-ui.html
+++ b/app/src/main/assets/termux-background-ui.html
@@ -34,11 +34,24 @@
     }
   </style>
 </head>
-
 <body>
-  <h1 class="text-xl font-bold mb-4">
-    <i class="fas fa-image text-blue-400"></i> Termux Background Picker
+  <h1 class="text-xl font-bold mb-4 flex items-center space-x-2">
+    <i class="fas fa-image text-blue-400"></i>
+    <span>Termux Background Picker</span>
   </h1>
+
+  <div class="mb-4 p-3 rounded bg-gray-800 border border-gray-700" id="statusPanel">
+    <div class="flex items-center justify-between">
+      <div>
+        <p class="font-semibold" id="statusLabel">Checking Termux...</p>
+        <p class="text-xs text-gray-300" id="statusDetails"></p>
+      </div>
+      <div class="flex space-x-2">
+        <button id="recheckBtn" class="px-3 py-1 text-sm bg-gray-700 rounded hover:bg-gray-600">Re-check</button>
+        <button id="resetBtn" class="px-3 py-1 text-sm bg-red-700 rounded hover:bg-red-600">Reset Background</button>
+      </div>
+    </div>
+  </div>
 
   <label class="block mb-2">Select Background Image:</label>
   <input id="imageInput" type="file" accept="image/*" class="mb-4 bg-gray-800 text-white border border-gray-600 rounded px-3 py-2 w-full">
@@ -47,7 +60,7 @@
 
   <div class="mt-4">
     <label class="block">Opacity: <span id="opacityValue">0.8</span></label>
-    <input type="range" id="opacitySlider" min="0.1" max="1" step="0.01" value="0.8" class="w-full">
+    <input type="range" id="opacitySlider" min="0.0" max="1" step="0.01" value="0.8" class="w-full">
   </div>
 
   <div class="flex items-center mt-4 space-x-6">
@@ -61,11 +74,29 @@
     </label>
   </div>
 
-  <button id="setBackgroundBtn" disabled class="mt-6 w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded shadow">
+  <button id="setBackgroundBtn" disabled class="mt-6 w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white font-semibold rounded shadow">
     <i class="fas fa-check-circle mr-1"></i> Apply Background
   </button>
 
   <div id="statusMsg" class="mt-4 text-sm text-green-400"></div>
+
+  <style>
+    #toast {
+      display: none;
+      position: fixed;
+      bottom: 20px;
+      left: 50%;
+      transform: translateX(-50%);
+      background-color: #1f2937;
+      color: #fff;
+      padding: 12px 24px;
+      border-radius: 8px;
+      font-weight: 600;
+      z-index: 9999;
+      box-shadow: 0 0 10px #000;
+    }
+  </style>
+  <div id="toast"></div>
 
   <script>
     const imageInput = document.getElementById('imageInput');
@@ -76,25 +107,96 @@
     const toggleBlur = document.getElementById('toggleBlur');
     const opacityValue = document.getElementById('opacityValue');
     const statusMsg = document.getElementById('statusMsg');
+    const statusLabel = document.getElementById('statusLabel');
+    const statusDetails = document.getElementById('statusDetails');
+    const recheckBtn = document.getElementById('recheckBtn');
+    const resetBtn = document.getElementById('resetBtn');
 
     let selectedFile = null;
+    let selectedUri = null;
+    let lastStatus = { canRunCommands: false };
 
-    imageInput.addEventListener('change', (event) => {
-      const file = event.target.files[0];
-      if (!file || !file.type.startsWith('image/')) {
-        alert('❌ Please select a valid image file.');
-        setBackgroundBtn.disabled = true;
-        previewImage.style.backgroundImage = '';
-        return;
-      }
+    function showToast(msg, isError = false) {
+      const toast = document.getElementById('toast');
+      toast.textContent = msg;
+      toast.style.display = 'block';
+      toast.style.backgroundColor = isError ? '#7f1d1d' : '#1f2937';
+      setTimeout(() => { toast.style.display = 'none'; }, 3000);
+    }
+
+    function updatePreview() {
+      if (!selectedFile) return;
       const reader = new FileReader();
       reader.onload = (e) => {
         previewImage.style.backgroundImage = `url('${e.target.result}')`;
         previewImage.style.opacity = opacitySlider.value;
-        setBackgroundBtn.disabled = false;
-        selectedFile = file;
       };
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(selectedFile);
+    }
+
+    function setState(message, details = '', blocked = false, isError = false) {
+      statusLabel.textContent = message;
+      statusDetails.textContent = details;
+      statusMsg.textContent = details;
+      statusMsg.className = 'mt-4 text-sm ' + (isError ? 'text-red-400' : 'text-green-400');
+      setBackgroundBtn.disabled = blocked || !selectedUri;
+    }
+
+    function refreshStatus() {
+      if (typeof Android === 'undefined' || !Android.getStatus) {
+        setState('Running in browser preview', 'Android bridge not available', true, true);
+        return;
+      }
+      try {
+        const status = JSON.parse(Android.getStatus());
+        lastStatus = status;
+        if (!status.termuxInstalled) {
+          setState('Blocked: Install Termux', 'Termux is required.', true, true);
+        } else if (!status.termuxApiInstalled) {
+          setState('Blocked: Install Termux:API', 'Install the Termux:API add-on to enable Apply.', true, true);
+        } else if (!status.canRunCommands) {
+          setState('Blocked', 'Termux:API broadcast not available.', true, true);
+        } else {
+          setState('Ready', 'Termux + Termux:API detected. Select an image and press Apply.', false, false);
+        }
+      } catch (err) {
+        setState('Error', 'Could not read status: ' + err.message, true, true);
+      }
+    }
+
+    function handleResult(raw) {
+      let res = {};
+      try {
+        res = JSON.parse(raw);
+      } catch (err) {
+        setState('Error', 'Invalid response: ' + err.message, true, true);
+        showToast('Invalid response from Android', true);
+        return;
+      }
+      const blocked = !!res.blocked;
+      const ok = !!res.ok;
+      const msg = res.message || '';
+      setState(ok ? 'Applied' : blocked ? 'Blocked' : 'Error', msg, blocked || !lastStatus.canRunCommands, !ok);
+      showToast(msg, !ok);
+    }
+
+    imageInput.addEventListener('change', (event) => {
+      const file = event.target.files[0];
+      if (!file) {
+        selectedFile = null;
+        selectedUri = null;
+        setBackgroundBtn.disabled = true;
+        previewImage.style.backgroundImage = '';
+        return;
+      }
+      if (!file.type.startsWith('image/')) {
+        showToast('Please select a PNG or JPEG image.', true);
+        event.target.value = '';
+        return;
+      }
+      selectedFile = file;
+      updatePreview();
+      setBackgroundBtn.disabled = !selectedUri || !lastStatus.canRunCommands;
     });
 
     opacitySlider.addEventListener('input', () => {
@@ -112,75 +214,59 @@
     });
 
     setBackgroundBtn.addEventListener('click', () => {
-      if (!selectedFile) return;
-
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const base64 = e.target.result;
-
-        if (typeof Android !== 'undefined' && Android.setSettings) {
-          Android.setSettings(
-            toggleAnimation.checked ? "scroll" : "none",
-            toggleBlur.checked ? "true" : "false",
-            opacitySlider.value,
-            base64
-          );
-          showToast(`✅ ${selectedFile.name} applied!`);
-        } else {
-          showToast(`✅ ${selectedFile.name} applied!`);
-        }
+      if (!selectedUri || !selectedFile) {
+        showToast('Select an image first.', true);
+        return;
+      }
+      const payload = {
+        imageUri: selectedUri,
+        opacity: opacitySlider.value,
+        blur: toggleBlur.checked,
+        animation: toggleAnimation.checked ? 'scroll' : 'none'
       };
-      reader.readAsDataURL(selectedFile);
+      const raw = Android.applyBackground(JSON.stringify(payload));
+      handleResult(raw);
+    });
+
+    recheckBtn.addEventListener('click', () => refreshStatus());
+
+    resetBtn.addEventListener('click', () => {
+      if (typeof Android === 'undefined' || !Android.resetBackground) {
+        showToast('Android bridge not available', true);
+        return;
+      }
+      const raw = Android.resetBackground();
+      handleResult(raw);
+    });
+
+    window.onAndroidFileSelected = (uri) => {
+      selectedUri = uri;
+      setBackgroundBtn.disabled = !uri || !lastStatus.canRunCommands;
+      statusDetails.textContent = uri ? 'Image ready: ' + uri : 'Select an image to continue';
+    };
+
+    function loadSettings() {
+      toggleAnimation.checked = localStorage.getItem("animation") === "true";
+      toggleBlur.checked = localStorage.getItem("blur") === "true";
+      opacitySlider.value = localStorage.getItem("opacity") || 0.8;
+      opacityValue.textContent = opacitySlider.value;
+      previewImage.style.opacity = opacitySlider.value;
+      if (toggleBlur.checked) previewImage.style.filter = 'blur(5px)';
+      if (toggleAnimation.checked) previewImage.classList.add('animate-scroll');
+    }
+
+    function saveSettings() {
+      localStorage.setItem("animation", toggleAnimation.checked);
+      localStorage.setItem("blur", toggleBlur.checked);
+      localStorage.setItem("opacity", opacitySlider.value);
+    }
+
+    loadSettings();
+    [opacitySlider, toggleAnimation, toggleBlur].forEach(e => e.addEventListener('change', saveSettings));
+
+    document.addEventListener('DOMContentLoaded', () => {
+      refreshStatus();
     });
   </script>
 </body>
 </html>
-
-<style>
-  #toast {
-    display: none;
-    position: fixed;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #1f2937;
-    color: #fff;
-    padding: 12px 24px;
-    border-radius: 8px;
-    font-weight: 600;
-    z-index: 9999;
-    box-shadow: 0 0 10px #000;
-  }
-</style>
-<div id="toast">✅ Background applied!</div>
-<script>
-  function showToast(msg) {
-    const toast = document.getElementById('toast');
-    toast.textContent = msg;
-    toast.style.display = 'block';
-    setTimeout(() => { toast.style.display = 'none'; }, 3000);
-  }
-</script>
-
-<script>
-  // Save settings
-  function saveSettings() {
-    localStorage.setItem("animation", toggleAnimation.checked);
-    localStorage.setItem("blur", toggleBlur.checked);
-    localStorage.setItem("opacity", opacitySlider.value);
-  }
-
-  // Load settings
-  function loadSettings() {
-    toggleAnimation.checked = localStorage.getItem("animation") === "true";
-    toggleBlur.checked = localStorage.getItem("blur") === "true";
-    opacitySlider.value = localStorage.getItem("opacity") || 0.8;
-    opacityValue.textContent = opacitySlider.value;
-    previewImage.style.opacity = opacitySlider.value;
-    if (toggleBlur.checked) previewImage.style.filter = 'blur(5px)';
-    if (toggleAnimation.checked) previewImage.classList.add('animate-scroll');
-  }
-
-  loadSettings();
-  [opacitySlider, toggleAnimation, toggleBlur].forEach(e => e.addEventListener('change', saveSettings));
-</script>

--- a/app/src/main/java/com/termuxbackground/MainActivity.java
+++ b/app/src/main/java/com/termuxbackground/MainActivity.java
@@ -1,1 +1,93 @@
 package com.termuxbackground;
+
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.webkit.ValueCallback;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import org.json.JSONObject;
+
+public class MainActivity extends AppCompatActivity {
+
+    private static final int REQUEST_FLAG = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+        | Intent.FLAG_GRANT_PREFIX_URI_PERMISSION;
+
+    private WebView webView;
+    @Nullable
+    private ValueCallback<Uri[]> filePathCallback;
+    private ActivityResultLauncher<Intent> fileChooserLauncher;
+    private WebAppInterface bridge;
+
+    @SuppressLint("SetJavaScriptEnabled")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        webView = findViewById(R.id.webview);
+
+        WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setAllowFileAccess(true);
+        settings.setDomStorageEnabled(true);
+        settings.setAllowContentAccess(true);
+
+        bridge = new WebAppInterface(this, webView);
+        webView.addJavascriptInterface(bridge, "Android");
+
+        webView.setWebViewClient(new WebViewClient());
+        webView.setWebChromeClient(new WebChromeClient() {
+            @Override
+            public boolean onShowFileChooser(WebView view, ValueCallback<Uri[]> filePathCallback, FileChooserParams fileChooserParams) {
+                if (MainActivity.this.filePathCallback != null) {
+                    MainActivity.this.filePathCallback.onReceiveValue(null);
+                }
+                MainActivity.this.filePathCallback = filePathCallback;
+                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+                intent.setType("image/*");
+                intent.addFlags(REQUEST_FLAG);
+                fileChooserLauncher.launch(intent);
+                return true;
+            }
+        });
+
+        fileChooserLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), this::handleFileChooserResult);
+
+        webView.loadUrl("file:///android_asset/termux-background-ui.html");
+    }
+
+    private void handleFileChooserResult(ActivityResult result) {
+        Uri[] uris = null;
+        if (result.getResultCode() == RESULT_OK && result.getData() != null) {
+            Uri uri = result.getData().getData();
+            if (uri != null) {
+                try {
+                    getContentResolver().takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                } catch (SecurityException ignored) {
+                    // Best effort; SAF permission might already be granted.
+                }
+                uris = new Uri[]{uri};
+                bridge.setLastImageUri(uri);
+                final String js = "window.onAndroidFileSelected && window.onAndroidFileSelected(" + JSONObject.quote(uri.toString()) + ");";
+                webView.post(() -> webView.evaluateJavascript(js, null));
+            }
+        }
+        if (filePathCallback != null) {
+            filePathCallback.onReceiveValue(uris);
+            filePathCallback = null;
+        }
+    }
+}

--- a/app/src/main/java/com/termuxbackground/WebAppInterface.java
+++ b/app/src/main/java/com/termuxbackground/WebAppInterface.java
@@ -1,34 +1,410 @@
 package com.termuxbackground;
 
+import android.content.ContentResolver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.text.TextUtils;
 import android.webkit.JavascriptInterface;
+import android.webkit.WebView;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class WebAppInterface {
-    private Context mContext;
-    private String animation = "none";
-    private String blur = "false";
-    private String opacity = "1.0";
 
-    public WebAppInterface(Context context) {
-        mContext = context;
+    private static final String TERMUX_PACKAGE = "com.termux";
+    private static final String TERMUX_API_PACKAGE = "com.termux.api";
+    private static final String TERMUX_API_ACTION = "com.termux.api.action.RUN_COMMAND";
+    private static final String TERMUX_HOME = "/data/data/com.termux/files/home";
+    private static final String TERMUX_CONFIG_DIR = TERMUX_HOME + "/.termux";
+    private static final String BACKGROUND_NAME = "background.png";
+
+    private final Context context;
+    private final ContentResolver contentResolver;
+    private final PackageManager packageManager;
+    private final WebView webView;
+
+    private Uri lastImageUri;
+
+    public WebAppInterface(Context context, WebView webView) {
+        this.context = context;
+        this.contentResolver = context.getContentResolver();
+        this.packageManager = context.getPackageManager();
+        this.webView = webView;
+    }
+
+    public void setLastImageUri(Uri uri) {
+        this.lastImageUri = uri;
     }
 
     @JavascriptInterface
-    public void setSettings(String anim, String blurVal, String opac) {
-        this.animation = anim;
-        this.blur = blurVal;
-        this.opacity = opac;
+    public String getStatus() {
+        try {
+            JSONObject status = buildStatus();
+            return status.toString();
+        } catch (Exception e) {
+            return buildError("Failed to build status: " + e.getMessage()).toString();
+        }
     }
 
-    public String getAnimation() {
-        return animation;
+    @JavascriptInterface
+    public String applyBackground(String payloadJson) {
+        JSONObject result = new JSONObject();
+        try {
+            JSONObject payload = new JSONObject(payloadJson == null ? "{}" : payloadJson);
+            Uri imageUri = resolveImageUri(payload.optString("imageUri", null));
+            String opacityStr = payload.optString("opacity", "");
+            String animation = payload.optString("animation", "none");
+            boolean blur = payload.optBoolean("blur", false);
+
+            Status status = parseStatus();
+            if (!status.canRunCommands) {
+                return buildBlocked("Termux or Termux:API missing. Install Termux and Termux:API to continue.").toString();
+            }
+
+            if (imageUri == null) {
+                return buildError("Select an image before applying.").toString();
+            }
+
+            double opacity = parseOpacity(opacityStr);
+            if (Double.isNaN(opacity)) {
+                return buildError("Invalid opacity value.").toString();
+            }
+
+            if (!validateAnimation(animation)) {
+                return buildError("Invalid animation option.").toString();
+            }
+
+            String mimeType = contentResolver.getType(imageUri);
+            if (!isSupportedMime(mimeType)) {
+                return buildError("Unsupported image type. Use PNG or JPEG.").toString();
+            }
+
+            File termuxDir = new File(TERMUX_CONFIG_DIR);
+            if (!termuxDir.exists() && !termuxDir.mkdirs()) {
+                return buildError("Unable to create Termux config directory.").toString();
+            }
+
+            File backgroundFile = new File(termuxDir, BACKGROUND_NAME);
+            copyUriToFile(imageUri, backgroundFile);
+
+            File propsFile = new File(termuxDir, "termux.properties");
+            mergeProperties(propsFile, opacity, blur, animation);
+
+            JSONObject reloadResult = runTermuxApiCommand("termux-reload-settings", new JSONArray(), TERMUX_HOME, true);
+            if (!reloadResult.optBoolean("ok", false)) {
+                return reloadResult.toString();
+            }
+
+            result.put("ok", true);
+            result.put("blocked", false);
+            result.put("message", "Background applied and Termux settings reloaded.");
+            return result.toString();
+        } catch (JSONException e) {
+            return buildError("Invalid payload: " + e.getMessage()).toString();
+        } catch (IOException e) {
+            return buildError("Failed to write files: " + e.getMessage()).toString();
+        }
     }
 
-    public String getBlur() {
-        return blur;
+    @JavascriptInterface
+    public String resetBackground() {
+        try {
+            Status status = parseStatus();
+            if (!status.canRunCommands) {
+                return buildBlocked("Termux or Termux:API missing. Install Termux and Termux:API to continue.").toString();
+            }
+
+            File propsFile = new File(TERMUX_CONFIG_DIR, "termux.properties");
+            clearBackgroundKeys(propsFile);
+
+            File backgroundFile = new File(TERMUX_CONFIG_DIR, BACKGROUND_NAME);
+            if (backgroundFile.exists() && !backgroundFile.delete()) {
+                return buildError("Unable to delete existing background image.").toString();
+            }
+
+            JSONObject reloadResult = runTermuxApiCommand("termux-reload-settings", new JSONArray(), TERMUX_HOME, true);
+            if (!reloadResult.optBoolean("ok", false)) {
+                return reloadResult.toString();
+            }
+
+            JSONObject result = new JSONObject();
+            result.put("ok", true);
+            result.put("blocked", false);
+            result.put("message", "Background settings reset and Termux reloaded.");
+            return result.toString();
+        } catch (Exception e) {
+            return buildError("Failed to reset: " + e.getMessage()).toString();
+        }
     }
 
-    public String getOpacity() {
-        return opacity;
+    @JavascriptInterface
+    public void openTermuxApiInstallHelp() {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://wiki.termux.com/wiki/Termux:API"));
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(intent);
+    }
+
+    private Status parseStatus() {
+        Status status = new Status();
+        status.termuxInstalled = isPackageInstalled(TERMUX_PACKAGE);
+        status.termuxApiInstalled = isPackageInstalled(TERMUX_API_PACKAGE);
+        status.canRunCommands = status.termuxInstalled && status.termuxApiInstalled && canResolveApiBroadcast();
+        if (!status.termuxInstalled) {
+            status.lastError = "Termux not installed";
+        } else if (!status.termuxApiInstalled) {
+            status.lastError = "Termux:API not installed";
+        } else if (!status.canRunCommands) {
+            status.lastError = "Termux:API broadcast unavailable";
+        }
+        return status;
+    }
+
+    private JSONObject buildStatus() throws JSONException {
+        Status status = parseStatus();
+        JSONObject statusJson = new JSONObject();
+        statusJson.put("termuxInstalled", status.termuxInstalled);
+        statusJson.put("termuxApiInstalled", status.termuxApiInstalled);
+        statusJson.put("canRunCommands", status.canRunCommands);
+        statusJson.put("lastError", status.lastError);
+        statusJson.put("appVersion", BuildConfig.VERSION_NAME);
+        return statusJson;
+    }
+
+    private boolean validateAnimation(String animation) {
+        return TextUtils.equals(animation, "none") || TextUtils.equals(animation, "scroll");
+    }
+
+    private boolean isSupportedMime(String mimeType) {
+        if (mimeType == null) return false;
+        return mimeType.equals("image/png") || mimeType.equals("image/jpeg");
+    }
+
+    private double parseOpacity(String opacityStr) {
+        try {
+            double value = Double.parseDouble(opacityStr);
+            if (value >= 0.0 && value <= 1.0) {
+                return value;
+            }
+            return Double.NaN;
+        } catch (NumberFormatException e) {
+            return Double.NaN;
+        }
+    }
+
+    private Uri resolveImageUri(String uriFromPayload) {
+        if (!TextUtils.isEmpty(uriFromPayload)) {
+            return Uri.parse(uriFromPayload);
+        }
+        return lastImageUri;
+    }
+
+    private boolean isPackageInstalled(String pkg) {
+        try {
+            packageManager.getPackageInfo(pkg, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
+    }
+
+    private boolean canResolveApiBroadcast() {
+        Intent intent = new Intent(TERMUX_API_ACTION);
+        intent.setPackage(TERMUX_API_PACKAGE);
+        ResolveInfo info = packageManager.resolveBroadcast(intent, 0);
+        return info != null;
+    }
+
+    private void copyUriToFile(Uri uri, File destination) throws IOException {
+        try (InputStream in = contentResolver.openInputStream(uri); OutputStream out = new FileOutputStream(destination)) {
+            if (in == null) {
+                throw new IOException("Unable to open selected file.");
+            }
+            byte[] buffer = new byte[8 * 1024];
+            int len;
+            while ((len = in.read(buffer)) != -1) {
+                out.write(buffer, 0, len);
+            }
+        }
+    }
+
+    private void mergeProperties(File propsFile, double opacity, boolean blur, String animation) throws IOException {
+        Map<String, String> desired = new HashMap<>();
+        desired.put("background", BACKGROUND_NAME);
+        desired.put("background.opacity", String.valueOf(opacity));
+        desired.put("background.blur", String.valueOf(blur));
+        desired.put("background.animation", animation);
+
+        List<String> lines = new ArrayList<>();
+        if (propsFile.exists()) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(propsFile), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    lines.add(line);
+                }
+            }
+        }
+
+        Set<String> handledKeys = new HashSet<>();
+        List<String> updated = new ArrayList<>();
+
+        for (String line : lines) {
+            String trimmed = line.trim();
+            boolean replaced = false;
+            for (String key : desired.keySet()) {
+                if (trimmed.startsWith(key + "=")) {
+                    updated.add(key + "=" + desired.get(key));
+                    handledKeys.add(key);
+                    replaced = true;
+                    break;
+                }
+            }
+            if (!replaced) {
+                updated.add(line);
+            }
+        }
+
+        List<String> missingLines = new ArrayList<>();
+        for (Map.Entry<String, String> entry : desired.entrySet()) {
+            if (!handledKeys.contains(entry.getKey())) {
+                missingLines.add(entry.getKey() + "=" + entry.getValue());
+            }
+        }
+
+        if (!missingLines.isEmpty()) {
+            if (!updated.isEmpty()) {
+                updated.add("");
+            }
+            updated.add("# Termux Background");
+            updated.addAll(missingLines);
+        }
+
+        writeLines(propsFile, updated);
+    }
+
+    private void clearBackgroundKeys(File propsFile) throws IOException {
+        if (!propsFile.exists()) {
+            return;
+        }
+        List<String> lines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(propsFile), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lines.add(line);
+            }
+        }
+
+        List<String> filtered = new ArrayList<>();
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("background=") ||
+                trimmed.startsWith("background.opacity=") ||
+                trimmed.startsWith("background.blur=") ||
+                trimmed.startsWith("background.animation=")) {
+                continue;
+            }
+            filtered.add(line);
+        }
+
+        writeLines(propsFile, filtered);
+    }
+
+    private void writeLines(File file, List<String> lines) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(file, false)) {
+            for (int i = 0; i < lines.size(); i++) {
+                String line = lines.get(i);
+                fos.write(line.getBytes(StandardCharsets.UTF_8));
+                if (i < lines.size() - 1) {
+                    fos.write('\n');
+                }
+            }
+        }
+    }
+
+    private JSONObject runTermuxApiCommand(String command, JSONArray args, String cwd, boolean background) {
+        Status status = parseStatus();
+        if (!status.termuxInstalled || !status.termuxApiInstalled) {
+            return buildBlocked("Install Termux and Termux:API to continue.");
+        }
+
+        Intent intent = new Intent(TERMUX_API_ACTION);
+        intent.setPackage(TERMUX_API_PACKAGE);
+        intent.putExtra("com.termux.api.extra.COMMAND", command);
+        intent.putExtra("com.termux.api.extra.ARGUMENTS", toStringArray(args));
+        intent.putExtra("com.termux.api.extra.WORKDIR", cwd);
+        intent.putExtra("com.termux.api.extra.BACKGROUND", background);
+
+        ResolveInfo resolveInfo = packageManager.resolveBroadcast(intent, 0);
+        if (resolveInfo == null) {
+            return buildError("Termux:API invocation failed: unable to resolve broadcast receiver.");
+        }
+
+        try {
+            context.sendBroadcast(intent);
+            JSONObject response = new JSONObject();
+            response.put("ok", true);
+            response.put("blocked", false);
+            response.put("message", "Reload triggered");
+            return response;
+        } catch (Exception e) {
+            return buildError("Termux:API invocation failed: " + e.getMessage());
+        }
+    }
+
+    private String[] toStringArray(JSONArray array) {
+        String[] out = new String[array.length()];
+        for (int i = 0; i < array.length(); i++) {
+            out[i] = array.optString(i, "");
+        }
+        return out;
+    }
+
+    private JSONObject buildError(String message) {
+        JSONObject obj = new JSONObject();
+        try {
+            obj.put("ok", false);
+            obj.put("blocked", false);
+            obj.put("message", message);
+        } catch (JSONException ignored) {
+        }
+        return obj;
+    }
+
+    private JSONObject buildBlocked(String message) {
+        JSONObject obj = new JSONObject();
+        try {
+            obj.put("ok", false);
+            obj.put("blocked", true);
+            obj.put("message", message);
+        } catch (JSONException ignored) {
+        }
+        return obj;
+    }
+
+    private static class Status {
+        boolean termuxInstalled;
+        boolean termuxApiInstalled;
+        boolean canRunCommands;
+        String lastError;
     }
 }


### PR DESCRIPTION
## Summary
- add a WebView bridge that detects Termux/Termux:API, validates inputs, writes background assets, and triggers termux-reload-settings via Termux:API
- rework the UI to require Apply, surface dependency status, and add re-check/reset actions using structured JSON responses
- document the hard dependency on Termux + Termux:API and outline the apply/reset workflow

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not configured in CI container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69402eb2d684832aa6ea199e8e0e1ceb)