### PR TITLE
Add Android APK CI and release workflows

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,43 @@
+name: Android CI (Debug APK)
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-debug:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Ensure Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Print Gradle version
+        run: ./gradlew -v
+
+      - name: Build Debug APK
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon clean assembleDebug
+
+      - name: Upload Debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apk-debug
+          path: app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,68 @@
+name: Android Release (Signed APK)
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Ensure Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Decode signing keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > android-signing.keystore
+          ls -lah android-signing.keystore
+
+      - name: Create keystore.properties (runtime only)
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          cat > keystore.properties <<EOF2
+          storeFile=android-signing.keystore
+          storePassword=${ANDROID_KEYSTORE_PASSWORD}
+          keyAlias=${ANDROID_KEY_ALIAS}
+          keyPassword=${ANDROID_KEY_PASSWORD}
+          EOF2
+          sed -e 's/storePassword=.*/storePassword=***REDACTED***/' \
+              -e 's/keyPassword=.*/keyPassword=***REDACTED***/' keystore.properties
+
+      - name: Build Release APK
+        run: |
+          set -euo pipefail
+          ./gradlew --no-daemon clean assembleRelease
+
+      - name: Verify release APK output
+        run: |
+          set -euo pipefail
+          ls -lah app/build/outputs/apk/release/
+          test -n "$(ls -1 app/build/outputs/apk/release/*.apk 2>/dev/null || true)"
+
+      - name: Create GitHub Release + upload APK
+        uses: softprops/action-gh-release@v2
+        with:
+          files: app/build/outputs/apk/release/*.apk

--- a/README.md
+++ b/README.md
@@ -82,3 +82,25 @@ cd termux-background
 ./gradlew assembleDebug
 
 # Build release APK
+./gradlew assembleRelease
+```
+
+## 📦 APK Builds & Releases
+
+### Debug builds (CI)
+- Triggered on PRs, pushes to `main`, or manual runs.
+- Produces a debug APK as a workflow artifact (`apk-debug`).
+
+### Release builds (signed)
+- Tag a version to publish:
+  - git tag v1.0.0
+  - git push origin v1.0.0
+- Workflow builds a signed release APK and attaches it to a GitHub Release.
+
+### Required GitHub Secrets (for release signing)
+Set these in GitHub → Repo → Settings → Secrets and variables → Actions:
+
+- ANDROID_KEYSTORE_BASE64
+- ANDROID_KEYSTORE_PASSWORD
+- ANDROID_KEY_ALIAS
+- ANDROID_KEY_PASSWORD


### PR DESCRIPTION
## Summary
- add CI workflow to build debug Android APK on PRs, main pushes, and manual runs
- add release workflow to build signed APKs from version tags and publish GitHub releases
- document APK build automation and required signing secrets in the README

## Testing
- not run (CI only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694043df6860832aa408ea0a0cd8e2ba)